### PR TITLE
Enabling WebSockets by default

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -7,7 +7,7 @@ exec geth --datadir /sepolia \
     --http.addr 0.0.0.0 \
     --http.corsdomain "*" \
     --http.vhosts "*" \
-    --ws \
+    --ws true \
     --ws.origins "*" \
     --ws.addr 0.0.0.0 \
     --authrpc.addr 0.0.0.0 \


### PR DESCRIPTION
Setting the --ws flag to true (false by default) so it enables the usage of WebSockets