### PR TITLE
Fix broken HTTPS exposure, and fix API Engine Link

### DIFF
--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -5,16 +5,18 @@
   "upstreamRepo": "ethereum/go-ethereum",
   "upstreamArg": "UPSTREAM_VERSION",
   "shortDescription": "Execution client Geth for Sepolia (a novel PoS-testing network for Ethereum)",
-  "description": "This package provides the Geth client for the Sepolia Testnet, which is the new official proof-of-stake Ethereum testnet. Geth is an execution client that enables interaction with the Ethereum blockchain. With this package, you can easily deploy and run a Sepolia node on your DappNode.",
+  "description": "This package provides the Geth client for the Sepolia Testnet, which is an official, but permissioned, proof-of-stake Ethereum testnet. Geth is an execution client that enables interaction with the Ethereum blockchain. With this package, you can easily deploy and run a Sepolia node on your Dappnode.",
   "type": "service",
+  "mainService": "sepolia-geth",
   "chain": "ethereum",
   "author": "Afri Schoedon <dappnode@q9f.cc> (https://github.com/q9f)",
   "contributors": [
     "Eduardo Antuña <eduadiez@gmail.com> (https://github.com/eduadiez)",
+    "Voss <voss@visnovalabs.io> (https://github.com/alexpeterson91)",
     "Stefaan Ponnet (https://github.com/sponnet)",
     "Afri Schoedon <dappnode@q9f.cc> (https://github.com/q9f)"
   ],
-  "categories": ["Developer tools"],
+  "categories": ["Developer tools", "blockchain"],
   "keywords": ["ethereum", "testnet", "geth", "sepolia", "pos"],
   "architectures": ["linux/amd64", "linux/arm64"],
   "links": {
@@ -27,14 +29,14 @@
       "name": "Sepolia Geth JSON-RPC (HTTP)",
       "description": "TLS secured HTTP JSON-RPC endpoint for Sepolia testnet",
       "serviceName": "sepolia-geth",
-      "fromSubdomain": "sepolia-geth-https",
+      "fromSubdomain": "http-sepolia-geth",
       "port": 8545
     },
     {
       "name": "Sepolia Geth JSON-RPC (WS)",
       "description": "TLS secured Websocket JSON-RPC endpoint for Sepolia testnet",
       "serviceName": "sepolia-geth",
-      "fromSubdomain": "sepolia-geth-wss",
+      "fromSubdomain": "ws-sepolia-geth",
       "port": 8546
     }
   ],

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -16,7 +16,7 @@
     "Stefaan Ponnet (https://github.com/sponnet)",
     "Afri Schoedon <dappnode@q9f.cc> (https://github.com/q9f)"
   ],
-  "categories": ["Developer tools", "blockchain"],
+  "categories": ["Developer tools", "Blockchain"],
   "keywords": ["ethereum", "testnet", "geth", "sepolia", "pos"],
   "architectures": ["linux/amd64", "linux/arm64"],
   "links": {

--- a/dappnode_package.json
+++ b/dappnode_package.json
@@ -20,22 +20,22 @@
   "links": {
     "homepage": "https://github.com/dappnode/DAppNodePackage-sepolia-geth#readme",
     "api": "http://sepolia-geth.dappnode:8545",
-    "apiEngine": "http://geth.dappnode:8551"
+    "apiEngine": "http://sepolia-geth.dappnode:8551"
   },
   "exposable": [
     {
       "name": "Sepolia Geth JSON-RPC (HTTP)",
-      "description": "HTTP-JSON-RPC endpoint for Sepolia testnet",
+      "description": "TLS secured HTTP JSON-RPC endpoint for Sepolia testnet",
       "serviceName": "sepolia-geth",
-      "port": 8545,
-      "exposeByDefault": false
+      "fromSubdomain": "sepolia-geth-https",
+      "port": 8545
     },
     {
       "name": "Sepolia Geth JSON-RPC (WS)",
-      "description": "WS-JSON-RPC endpoint for Sepolia testnet",
-      "serviceName": "sepolia-geth-ws",
-      "port": 8546,
-      "exposeByDefault": false
+      "description": "TLS secured Websocket JSON-RPC endpoint for Sepolia testnet",
+      "serviceName": "sepolia-geth",
+      "fromSubdomain": "sepolia-geth-wss",
+      "port": 8546
     }
   ],
   "repository": {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,7 +1,7 @@
 version: "3.5"
 services:
-  geth:
-    image: "geth.sepolia-geth.dnp.dappnode.eth:0.1.1"
+  sepolia-geth:
+    image: "sepolia-geth.sepolia-geth.dnp.dappnode.eth:0.1.2"
     build:
       context: .
       args:
@@ -9,12 +9,12 @@ services:
     volumes:
       - "sepolia:/sepolia"
     ports:
-      - "35415:35415"
+      - "35415:35415/tcp"
       - "35415:35415/udp"
     restart: unless-stopped
     environment:
       - >-
-        EXTRA_OPTIONS=--http.api eth,engine,net,web3,txpool, --ws.api
+        EXTRA_OPTIONS=--http.api eth,engine,net,web3,txpool --ws.api
         eth,engine,net,web3,txpool
       - P2P_PORT=35415
       - SYNCMODE=snap


### PR DESCRIPTION
Fix API Engine Link
Fix HTTPS expose ports, remove param for expose by default :false from HTTPS and WSS, fixed WSS to refer to a real service that exists, and add from subdomain params to identify each service